### PR TITLE
Cabeçalho responsivo

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
 	<meta property="og:url" content="https://webdevrn.github.io/" />
 	<meta property="og:site_name" content="WebDevRN.github.io" />
 	<meta property="og:image" content="asstets/logo.jpeg" />
-	
+
 	<!-- twitter metatags-->
 	<meta name="twitter:card" content="summary_large_image">
 	<meta name="twitter:title" content="WebDevRN - Desenvolvimento web do Rio grande do norte | RN - WebDevRN | RN Desenvolvimento">
@@ -47,11 +47,11 @@
 </head>
 
 <body class="default bg" style="background: #f5ce3e;">
-	<header style="background: #9b59b6" id="top">
+	<header style="background: #9b59b6 ; height: 100vh" id="top">
 		<div id="to" class="azul">
 			<h1 style="border-bottom: none">WebDevRN, desenvolvimento web do Rio Grande do Norte<img src="https://emojipedia-us.s3.amazonaws.com/thumbs/160/emoji-one/44/sign-of-the-horns_1f918.png"/><br/>
-					<img style="transition-duration: 0.6s"  class="down" onclick="go(`.conteudo`)" src="assets/arrow.png" alt="Seta para baixo"/>
-				</h1>
+				<img style="transition-duration: 0.6s"  class="down" onclick="go(`.conteudo`)" src="assets/arrow.png" alt="Seta para baixo"/>
+			</h1>
 		</div>
 	</header>
 	<main class="estimulo">
@@ -110,11 +110,11 @@
 				</nav-->
 
 	</main>
-	<footer class="bpreto" style="padding: 40px">
+	<footer class="bpreto" style="padding-top: 40px">
 		<div class="left" style="height: 150px">
 			<span class="log" onclick="go('#to')" title="clique para subir">
 				<!-- Espaço da imagem SVG -->
-					<svg version="1.1" id="DeWeb" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" 
+					<svg version="1.1" id="DeWeb" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 				    viewBox="0 0 264.1 82" style="enable-background: new 0 0 264.1 82;width: 540px" xml:space="preserve">
 				    <style type="text/css">
 				      g {
@@ -182,7 +182,7 @@
 				        -o-transform: translate(80px, 0px);
 				        transform: translate(80px, 0px);
 				      }
-				     
+
 				    </style>
 				    <g id="Right">
 				      <path class="st0" d="M243.4,7c4.7,0.1,9.4,0.2,14.2,0.2c0.3,0.4,0.6,0.8,1,1.2c4.1,9.2-5,27.5,4.8,30.9c0,2.9,0,4.7,0,7.5


### PR DESCRIPTION
Agora o cabeçalho tem o tamanho da altura da janela, não importa o redimensionamento, a parte amarela só aparece depois do scroll ou de clicar na seta